### PR TITLE
feat(components): add icon-picker component

### DIFF
--- a/app/components/maglev/content/builder.rb
+++ b/app/components/maglev/content/builder.rb
@@ -8,7 +8,8 @@ module Maglev
         image: Maglev::Content::Image,
         link: Maglev::Content::Link,
         checkbox: Maglev::Content::Checkbox,
-        color: Maglev::Content::Color
+        color: Maglev::Content::Color,
+        icon: Maglev::Content::Icon
       }.freeze
 
       def build(scope, content, setting)

--- a/app/components/maglev/content/icon.rb
+++ b/app/components/maglev/content/icon.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Maglev
+  module Content
+    class Icon < Base
+    end
+  end
+end

--- a/app/javascript/editor/components/dynamic-form/dynamic-input.vue
+++ b/app/javascript/editor/components/dynamic-form/dynamic-input.vue
@@ -59,6 +59,14 @@
       :presets="options.presets"
       v-if="setting.type == 'color'"
     />
+    <icon-picker
+        :label="setting.label"
+        :name="setting.id"
+        :presets="options.presets"
+        :prefix="options.prefix"
+        v-model="inputValue"
+        v-if="setting.type == 'icon'"
+    />
   </div>
 </template>
 

--- a/app/javascript/editor/components/kit/icon-picker.vue
+++ b/app/javascript/editor/components/kit/icon-picker.vue
@@ -1,0 +1,64 @@
+<template>
+  <div>
+    <label class="block font-semibold text-gray-800" :for="name">
+      {{ label }}
+    </label>
+    <div class="flex gap-2 mt-1">
+      <div class="flex gap-2 mt-1">
+        <div v-for="preset in presets" :key="preset">
+          <input
+            type="radio"
+            name="selectedIcon"
+            :id="`icon-${preset}`"
+            :value="preset"
+            class="hidden"
+            v-model="selectedIcon"
+          />
+          <label
+            :for="`icon-${preset}`"
+            class="inline-block mr-1 cursor-pointer"
+          >
+            <i
+              class="select-none text-2xl p-1 border-b-2 hover:border-gray-400"
+              :class="[prefix, preset, {'border-editor-primary border-black shadow-xl': preset == selectedIcon}]"
+            >
+            </i>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'IconPicker',
+  props: {
+    label: { type: String, default: 'Label' },
+    name: { type: String, default: 'icon' },
+    value: { type: String },
+    presets: {
+      type: Array,
+      default: function () {
+        return []
+      },
+    },
+    prefix: { type: String, default: '' },
+  },
+  computed: {
+    selectedIcon: {
+      get() {
+        return this.value
+      },
+      set(icon) {
+        this.$emit('input', icon)
+      },
+    },
+  },
+}
+</script>
+
+<style>
+/*TODO Replace fixed hostname by a variable */
+@import url('http://localhost:3000/fonts/fonts.css');
+</style>

--- a/app/javascript/editor/components/kit/index.js
+++ b/app/javascript/editor/components/kit/index.js
@@ -18,6 +18,7 @@ import SearchInput from './search-input'
 import Pagination from './pagination'
 import PageIcon from './page-icon'
 import ColorPicker from './color-picker'
+import IconPicker from './icon-picker'
 
 Vue.component('icon', Icon)
 Vue.component('dropdown', Dropdown)
@@ -38,3 +39,4 @@ Vue.component('search-input', SearchInput)
 Vue.component('pagination', Pagination)
 Vue.component('page-icon', PageIcon)
 Vue.component('color-picker', ColorPicker)
+Vue.component('icon-picker', IconPicker)

--- a/app/javascript/editor/services/inline-editing.js
+++ b/app/javascript/editor/services/inline-editing.js
@@ -272,6 +272,7 @@ export const updateSectionSetting = (
     case 'image':
     case 'checkbox':
     case 'color':
+    case 'icon':
       foundSetting = false
       break
     default:

--- a/app/models/maglev/section/setting.rb
+++ b/app/models/maglev/section/setting.rb
@@ -10,7 +10,7 @@ class Maglev::Section::Setting
 
   ## validations ##
   validates :id, :label, :type, :default, 'maglev/presence': true
-  validates :type, inclusion: { in: %w[text image checkbox link color] }
+  validates :type, inclusion: { in: %w[text image checkbox link color icon] }
 
   ## methods ##
 

--- a/spec/models/maglev/section/setting_spec.rb
+++ b/spec/models/maglev/section/setting_spec.rb
@@ -28,8 +28,8 @@ describe Maglev::Section::Setting do
       it { is_expected.to eq false }
     end
 
-    context 'type must include  [text, image, checkbox, link, color]' do
-      %w[text image checkbox link color].each do |type|
+    context 'type must include  [text, image, checkbox, link, color, icon]' do
+      %w[text image checkbox link color icon].each do |type|
         let(:setting) { build(:section_setting, type: type) }
         it { is_expected.to eq true }
       end


### PR DESCRIPTION
This component is not completed:
It remains to deal with the url of css file:
see  `app/javascript/editor/components/kit/icon-picker.vue` l63:
```css
@import url('http://localhost:3000/fonts/fonts.css');
```

Below, I pasted the content of my section yml file related to the component:
```yaml
  - label: "Icônes"
    id: icon
    type: icon
#    prefix: 'fa'
    default: 'icon-af-certif'
    presets: ['icon-af-certif','icon-af-counter','icon-af-map','icon-af-headphone']
```

We can see a line `prefix: 'fa'`. I added this option to take account of some libraries requirements as FontAwesome.

I have dropped  css and fonts files  in /public/fonts directory of main Rails application:

![image](https://user-images.githubusercontent.com/1129283/126810705-131ba0bb-6639-46b7-9847-5c094ef4b336.png)
