### PR TITLE
fix(collection_items): 'TypeError - nil is not a symbol nor a string'

### DIFF
--- a/app/services/maglev/fetch_collection_items.rb
+++ b/app/services/maglev/fetch_collection_items.rb
@@ -76,7 +76,7 @@ module Maglev
       Item.new(
         original_item.id,
         original_item[label_field],
-        original_item.respond_to?(image_field) ? original_item.public_send(image_field) : nil,
+        original_item.respond_to?(image_field.to_s) ? original_item.public_send(image_field) : nil,
         original_item
       )
     end


### PR DESCRIPTION
Below result of binding,pry

```ruby
From: /home/patrice/Working/docker/workspace/maglev/maglev-mit/app/services/maglev/fetch_collection_items.rb:75 Maglev::FetchCollectionItems#build_item:

    73: def build_item(original_item)
    74:   binding.pry
 => 75:   return nil unless original_item
    76: 
    77:   Item.new(
    78:     original_item.id,
    79:     original_item[label_field],
    80:     original_item.respond_to?(image_field) ? original_item.public_send(image_field) : nil,
    81:     original_item
    82:   )
    83: end

[1] pry(#<Maglev::FetchCollectionItems>)> original_item
=> #<Spree::Product:0x000000000dda7750
 id: 24293,
 name: "Nestin | 10C2",
 available_on: Mon, 10 May 2021 00:01:34.988817000 CEST +02:00,
 deleted_at: nil,
 slug: "nestin-10c2",
 meta_description: nil,
 meta_keywords: nil,
 tax_category_id: 4,
 shipping_category_id: 1,
 created_at: Mon, 10 May 2021 00:01:35.047189000 CEST +02:00,
 updated_at: Mon, 10 May 2021 00:01:35.363698000 CEST +02:00,
 promotionable: true,
 meta_title: nil,
 discontinue_on: nil,
 synonyms: nil,
 description: nil>
[2] pry(#<Maglev::FetchCollectionItems>)> original_item.id
=> 24293
[3] pry(#<Maglev::FetchCollectionItems>)> original_item[label_field]
=> "Nestin | 10C2"
[4] pry(#<Maglev::FetchCollectionItems>)> original_item.respond_to?(image_field)
TypeError: nil is not a symbol nor a string

```