### PR TITLE
Paths in post-install instructures are relative

### DIFF
--- a/lib/generators/maglev/install_generator.rb
+++ b/lib/generators/maglev/install_generator.rb
@@ -38,8 +38,8 @@ module Maglev
       $stdout.puts <<~INFO
         Done! 🎉
 
-        You can now tweak /config/initializers/maglev.rb.
-        You can also modify your theme (in /app/theme and /app/views/theme)
+        You can now tweak config/initializers/maglev.rb
+        You can also modify your theme (in app/theme and app/views/theme)
         and generate new sections with rails g maglev:section.
 
         👉 The next step is to create a site using `rails maglev:create_site`.


### PR DESCRIPTION
This makes them clickable within terminals.