### PR TITLE
Fix: Rack::Static header keys must be strings.

### DIFF
--- a/lib/maglev/engine.rb
+++ b/lib/maglev/engine.rb
@@ -54,7 +54,7 @@ module Maglev
                                     urls: ["/#{vite_ruby.config.public_output_dir}"],
                                     root: root.join(vite_ruby.config.public_dir),
                                     header_rules: [
-                                      [:all, { "Access-Control-Allow-Origin": '*' }]
+                                      [:all, { "Access-Control-Allow-Origin" => '*' }]
                                     ]
       else
         # mostly when running the application in production behind NGINX or APACHE
@@ -63,7 +63,7 @@ module Maglev
                                      urls: ["/#{vite_ruby.config.public_output_dir}"],
                                      root: root.join(vite_ruby.config.public_dir),
                                      header_rules: [
-                                       [:all, { "Access-Control-Allow-Origin": '*' }]
+                                       [:all, { "Access-Control-Allow-Origin" => '*' }]
                                      ]
       end
     end


### PR DESCRIPTION
[Rack::Static](https://github.com/rack/rack/blob/main/lib/rack/static.rb) header keys **must** be strings, otherwise it will fail when serving static files with puma (and probably with other ruby servers).

This was working fine in version 1.1.7 and it began to fail in version 1.2.2.

Static file serving of maglev assets failed without backtrace, only with this message:

```
Read: #<TypeError: no implicit conversion of Symbol into String>
``` 

## Gem versions

- maglevcms (1.2.2)
- rack (2.2.8)
- rails (7.0.4)
- puma (~> 5.0)