### PR TITLE
Add support for LinkedInBot

### DIFF
--- a/lib/maglev/preview_constraint.rb
+++ b/lib/maglev/preview_constraint.rb
@@ -4,7 +4,7 @@ require 'uri'
 
 module Maglev
   class PreviewConstraint
-    CRAWLER_USER_AGENTS = /Googlebot|Twitterbot|facebookexternalhit/o.freeze
+    CRAWLER_USER_AGENTS = /Googlebot|Twitterbot|facebookexternalhit|LinkedInBot/o.freeze
 
     attr_reader :preview_host
 

--- a/spec/requests/maglev/page_preview_spec.rb
+++ b/spec/requests/maglev/page_preview_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Maglev::PagePreviewController', type: :request do
         expect(response.body).to include('--basic-theme-primary-color: #F87171;')
       end
 
-      describe 'Given Facebook/Google/Twitter crawl the index page' do
+      describe 'Given Facebook/Google/Twitter/LinkedIn crawl the index page' do
         # rubocop:disable Style/StringHashKeys
         let(:headers) { { 'HTTP_CONTENT_TYPE' => '*/*', 'HTTP_ACCEPT' => '*/*', 'HTTP_USER_AGENT' => user_agent } }
         # rubocop:enable Style/StringHashKeys
@@ -59,8 +59,16 @@ RSpec.describe 'Maglev::PagePreviewController', type: :request do
           end
         end
 
-        describe 'Given Twitter crawls it' do
+        describe 'Given Google crawls it' do
           let(:user_agent) { 'Googlebot/2.1' }
+          it 'renders the index page' do
+            get '/index', headers: headers
+            expect(response.body).to include('<title>Default - Home</title>')
+          end
+        end
+
+        describe 'Given LinkedIn crawls it' do
+          let(:user_agent) { 'LinkedInBot/1.0' }
           it 'renders the index page' do
             get '/index', headers: headers
             expect(response.body).to include('<title>Default - Home</title>')


### PR DESCRIPTION
We've run into an issue when sharing maglev pages on linked in, no preview was created. 

While debugging the page with https://www.linkedin.com/post-inspector, we discovered that maglev returns a 404 status when LinkedIn attempted to generate the preview.

> 2024-04-04 21:37:41.697175870 +0200 CEST[router] method=GET path=“/livre-blanc” host=[www.botyglot.com](http://www.botyglot.com/) request_id=267c30bc-b22b-4d1d-95f7-975c3be6f9f1 container=web-1 from=“108.174.5.113" protocol=https status=404 duration=0.008s bytes=1052 referer=“-” user_agent=“LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com/)”

This PR fixes the issue.
