### PR TITLE
Support SQLite3 by checking for `jsonb` in migrations

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           yarn install
 
-      - name: Setup test database
+      - name: Setup test database (Postgres)
         env:
           BUNDLE_GEMFILE: ${{ matrix.gemfile }}
           RAILS_ENV: test
@@ -59,12 +59,26 @@ jobs:
           MAGLEV_APP_DATABASE_PASSWORD: "password"
         run: |
           bin/rails db:setup
-        
-      - name: Run Rails tests
+
+      - name: Setup test database (SQLite)
+        env:
+          BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+          RAILS_ENV: test
+          DATABASE_URL: "sqlite3:storage/maglev_test.sqlite3"
+        run: |
+          bin/rails db:setup
+
+      - name: Run Rails tests (Postgres)
         env:
           BUNDLE_GEMFILE: ${{ matrix.gemfile }}
           MAGLEV_APP_DATABASE_USERNAME: "maglev"
           MAGLEV_APP_DATABASE_PASSWORD: "password"
+        run: bundle exec rspec
+
+      - name: Run Rails tests (SQLite)
+        env:
+          BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+          DATABASE_URL: "sqlite3:storage/maglev_test.sqlite3"
         run: bundle exec rspec
         
       - name: Run Javascript tests

--- a/db/migrate/20200831101942_create_maglev_section_content.rb
+++ b/db/migrate/20200831101942_create_maglev_section_content.rb
@@ -1,11 +1,19 @@
 class CreateMaglevSectionContent < ActiveRecord::Migration[6.0]
   def change
     change_table :maglev_sites do |t|
-      t.jsonb :sections, default: []
+      if t.respond_to? :jsonb
+        t.jsonb :sections, default: []
+      else
+        t.json :sections, default: []
+      end
     end
 
     change_table :maglev_pages do |t|
-      t.jsonb :sections, default: []
+      if t.respond_to? :jsonb
+        t.jsonb :sections, default: []
+      else
+        t.json :sections, default: []
+      end
     end
   end
 end

--- a/db/migrate/20210819092740_switch_to_localized_page_fields.rb
+++ b/db/migrate/20210819092740_switch_to_localized_page_fields.rb
@@ -1,15 +1,25 @@
 class SwitchToLocalizedPageFields < ActiveRecord::Migration[6.1]
   def up
     remove_columns :maglev_pages, :title, :seo_title, :meta_description
-    add_column :maglev_pages, :title_translations, :jsonb, default: {}
-    add_column :maglev_pages, :seo_title_translations, :jsonb, default: {}
-    add_column :maglev_pages, :meta_description_translations, :jsonb, default: {}
+
+    change_table :maglev_pages do |t|
+      if t.respond_to? :jsonb
+        t.jsonb :title_translations, default: {}
+        t.jsonb :seo_title_translations, default: {}
+        t.jsonb :meta_description_translations, default: {}
+      else
+        t.json :title_translations, default: {}
+        t.json :seo_title_translations, default: {}
+        t.json :meta_description_translations, default: {}
+      end
+    end
   end
 
   def down
     add_column :maglev_pages, :title, :string
     add_column :maglev_pages, :seo_title, :string
     add_column :maglev_pages, :meta_description, :string
+
     remove_column :maglev_pages, :title_translations
     remove_column :maglev_pages, :seo_title_translations
     remove_column :maglev_pages, :meta_description_translations

--- a/db/migrate/20211008064437_add_locales_to_sites.rb
+++ b/db/migrate/20211008064437_add_locales_to_sites.rb
@@ -1,5 +1,11 @@
 class AddLocalesToSites < ActiveRecord::Migration[6.0]
   def change
-    add_column :maglev_sites, :locales, :jsonb, default: []
+    change_table :maglev_sites do |t|
+      if t.respond_to? :jsonb
+        t.jsonb :locales, default: []
+      else
+        t.json :locales, default: []
+      end
+    end
   end
 end

--- a/db/migrate/20211013210954_translate_section_content.rb
+++ b/db/migrate/20211013210954_translate_section_content.rb
@@ -1,8 +1,22 @@
 class TranslateSectionContent < ActiveRecord::Migration[6.0]
   def change
     remove_column :maglev_sites, :sections, :jsonb, default: []
-    add_column :maglev_sites, :sections_translations, :jsonb, default: {}
     remove_column :maglev_pages, :sections, :jsonb, default: []
-    add_column :maglev_pages, :sections_translations, :jsonb, default: {}
+
+    change_table :maglev_sites do |t|
+      if t.respond_to? :jsonb
+        t.jsonb :sections_translations, default: {}
+      else
+        t.json :sections_translations, default: {}
+      end
+    end
+
+    change_table :maglev_pages do |t|
+      if t.respond_to? :jsonb
+        t.jsonb :sections_translations, default: {}
+      else
+        t.json :sections_translations, default: {}
+      end
+    end
   end
 end

--- a/db/migrate/20211203224112_add_open_graph_tags_to_pages.rb
+++ b/db/migrate/20211203224112_add_open_graph_tags_to_pages.rb
@@ -1,9 +1,15 @@
 class AddOpenGraphTagsToPages < ActiveRecord::Migration[6.0]
   def change
     change_table :maglev_pages do |t|
-      t.jsonb :og_title_translations, default: {}
-      t.jsonb :og_description_translations, default: {}
-      t.jsonb :og_image_url_translations, default: {}
+      if t.respond_to? :jsonb
+        t.jsonb :og_title_translations, default: {}
+        t.jsonb :og_description_translations, default: {}
+        t.jsonb :og_image_url_translations, default: {}
+      else
+        t.json :og_title_translations, default: {}
+        t.json :og_description_translations, default: {}
+        t.json :og_image_url_translations, default: {}
+      end
     end
   end
 end

--- a/db/migrate/20220612092235_add_style_to_sites.rb
+++ b/db/migrate/20220612092235_add_style_to_sites.rb
@@ -1,7 +1,11 @@
 class AddStyleToSites < ActiveRecord::Migration[6.0]
   def change
     change_table :maglev_sites do |t|
-      t.jsonb :style, default: []
+      if t.respond_to? :jsonb
+        t.jsonb :style, default: []
+      else
+        t.json :style, default: []
+      end
     end
   end
 end


### PR DESCRIPTION
For fun I tried the quick start guide and ran `rpl -R 'jsonb' 'json' db/migrate` and to my surprise maglev works perfectly fine with SQLite.

I have added a check for `jsonb` support in migrations. If not then fallback to `json`. This is the pattern followed by Spree, Pay etc.