### PR TITLE
Run newly loaded script tags instead of the ones you just replaced

### DIFF
--- a/app/frontend/live-preview-client/rails.js
+++ b/app/frontend/live-preview-client/rails.js
@@ -166,7 +166,7 @@ const updatePreviewDocument = async (content, section, insertAt) => {
     targetElement = previewDocument.querySelector(selector)
   }
 
-  runScripts(targetElement)
+  runScripts(sourceElement)
 
   targetElement.scrollIntoView(true)
 }


### PR DESCRIPTION
Found a bug where script tags in newly re-rendered sections were running the code from the old element and not the new one inserted. 

This should fix it.