### PR TITLE
Change to simple text

### DIFF
--- a/app/frontend/editor/locales/editor.es.json
+++ b/app/frontend/editor/locales/editor.es.json
@@ -45,7 +45,7 @@
       "newButton": "Nueva página",
       "searchPlaceholder": "Escribe tu consulta aquí...",
       "item": {
-        "edit": "Editar la configuración de la página",
+        "edit": "Configuración página",
         "clone": "Clonar página",
         "hide": "Esconder",
         "show": "Mostrar",


### PR DESCRIPTION
There is a overflow in the setting page.

![image](https://github.com/user-attachments/assets/b70de6bf-7a97-486c-a52d-1069a5ff447f)

Just use: "Configuración página" is understandable. 