### PR TITLE
Change to symbol for default settings

### DIFF
--- a/lib/maglev.rb
+++ b/lib/maglev.rb
@@ -26,7 +26,7 @@ module Maglev
         c.favicon = nil
         c.logo = nil
         c.primary_color = '#040712'
-        c.uploader = 'active_storage'
+        c.uploader = :active_storage
         c.site_publishable = false
         c.preview_host = nil
         c.asset_host = Rails.application.config.action_controller.asset_host


### PR DESCRIPTION
this mini fix set to symbol the default uploader configuration.

![image](https://github.com/user-attachments/assets/cb6f7bd5-73fb-4a91-86ab-0e3eda99adb8)

Now will enter the symbol case.

will fix this:
![image](https://github.com/user-attachments/assets/f062d710-7bf2-4640-a19e-69f1e86ab8c9)
if the initialised is not set.