### PR TITLE
fix: params[:path] can be nil sometimes

### DIFF
--- a/app/services/maglev/extract_locale.rb
+++ b/app/services/maglev/extract_locale.rb
@@ -22,9 +22,10 @@ module Maglev
     protected
 
     def extract_locale
-      segments = params[:path].split('/')
+      path = params[:path] || 'index'
+      segments = path.split('/')
 
-      return [default_locale, params[:path]] unless locales.include?(segments[0]&.to_sym)
+      return [default_locale, path] unless locales.include?(segments[0]&.to_sym)
 
       [segments.shift, segments.empty? ? 'index' : segments.join('/')]
     end

--- a/spec/services/maglev/extract_locale_spec.rb
+++ b/spec/services/maglev/extract_locale_spec.rb
@@ -9,6 +9,20 @@ describe Maglev::ExtractLocale do
   let(:params) { { path: 'index' } }
   let(:locales) { %i[en fr] }
 
+  context 'the path is nil' do
+    let(:params) { { path: nil } }
+
+    it 'uses the default locale' do
+      expect(Maglev::I18n).to receive(:'current_locale=').with(:en)
+      subject
+    end
+
+    it "sets the path to 'index'" do
+      subject
+      expect(params[:path]).to eq 'index'
+    end
+  end
+
   context "the path doesn't contain a locale" do
     it 'uses the default locale' do
       expect(Maglev::I18n).to receive(:'current_locale=').with(:en)


### PR DESCRIPTION
- [x] don't raise an exception and use the index page if for some reasons, the params[:path] is empty