### PR TITLE
fix: 2 sections can't have the same id

### DIFF
--- a/lib/maglev/errors.rb
+++ b/lib/maglev/errors.rb
@@ -4,6 +4,7 @@ module Maglev
   module Errors
     class NotAuthorized < StandardError; end
     class UnknownSection < StandardError; end
+    class DuplicateSectionDefinition < StandardError; end
 
     class UnknownSetting < StandardError
       def initialize(section_id, block_id, setting_id)

--- a/spec/fixtures/themes/theme_with_sections_with_same_id/sections/category_1/section_a.yml
+++ b/spec/fixtures/themes/theme_with_sections_with_same_id/sections/category_1/section_a.yml
@@ -1,0 +1,30 @@
+# Name of the section displayed in the editor UI
+name: Section A
+
+category: category_1
+
+# Definition of the settings:
+# A setting type can be one of the following values: text, image, checkbox, link and color.
+# Please visit: https://docs.maglev.dev/concepts/setting for more explanation.
+settings:
+- label: "Title"
+  id: title
+  type: text
+  default: "Title"
+  # html: true
+  # line_break: true
+  
+- label: "Body"
+  id: body
+  type: text
+  html: true
+  line_break: true
+  default: "Body"
+  
+# Definition of the blocks.
+# You can define as many types of blocks as you want.
+blocks: []
+
+# By default, in the editor UI, blocks will be listed below the "Content" title.
+# The title can be changed with the following property:
+# blocks_label: "My list of items"

--- a/spec/fixtures/themes/theme_with_sections_with_same_id/sections/category_2/section_a.yml
+++ b/spec/fixtures/themes/theme_with_sections_with_same_id/sections/category_2/section_a.yml
@@ -1,0 +1,23 @@
+# Name of the section displayed in the editor UI
+name: Section A
+
+category: category_2
+
+# Definition of the settings:
+# A setting type can be one of the following values: text, image, checkbox, link and color.
+# Please visit: https://docs.maglev.dev/concepts/setting for more explanation.
+settings:
+- label: "Title"
+  id: title
+  type: text
+  default: "Title"
+  # html: true
+  # line_break: true
+    
+# Definition of the blocks.
+# You can define as many types of blocks as you want.
+blocks: []
+
+# By default, in the editor UI, blocks will be listed below the "Content" title.
+# The title can be changed with the following property:
+# blocks_label: "My list of items"

--- a/spec/fixtures/themes/theme_with_sections_with_same_id/theme.yml
+++ b/spec/fixtures/themes/theme_with_sections_with_same_id/theme.yml
@@ -1,0 +1,10 @@
+id: default
+name: Default
+
+section_categories:
+- id: category_1
+  name: "Category #1"
+- id: category_2
+  name: "Category #2"
+
+style_settings: []

--- a/spec/lib/maglev/theme_filesystem_loader_spec.rb
+++ b/spec/lib/maglev/theme_filesystem_loader_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Maglev::ThemeFilesystemLoader do
+  describe '#call' do
+    # rubocop:disable Lint/UnusedBlockArgument
+    let(:fetch_section_screenshot_path) { ->(theme:, section:, absolute:) { path } }
+    # rubocop:enable Lint/UnusedBlockArgument
+
+    subject { described_class.new(fetch_section_screenshot_path).call(Pathname.new(path)) }
+
+    context 'There are 2 sections with the same id in different categories' do
+      let(:path) { File.expand_path('./spec/fixtures/themes/theme_with_sections_with_same_id') }
+
+      it 'raises a DuplicateSectionDefinition error' do
+        expect { subject }.to raise_error(Maglev::Errors::DuplicateSectionDefinition)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] raise an exception if 2 sections in different categories share the same id