### PR TITLE
fix: set temporarily the I18n.locale when rendering a Maglev page

### DIFF
--- a/app/controllers/maglev/page_preview_controller.rb
+++ b/app/controllers/maglev/page_preview_controller.rb
@@ -7,7 +7,7 @@ module Maglev
     include Maglev::ContentLocaleConcern
 
     before_action :fetch_maglev_site
-    before_action :extract_content_locale
+    around_action :extract_content_locale
 
     def index
       render_maglev_page
@@ -43,9 +43,9 @@ module Maglev
       false
     end
 
-    def extract_content_locale
+    def extract_content_locale(&block)
       _, locale = maglev_services.extract_locale.call(params: params, locales: maglev_site.locale_prefixes)
-      ::I18n.locale = locale
+      ::I18n.with_locale(locale, &block)
     end
 
     def fallback_to_default_locale

--- a/app/frontend/editor/plugins/i18n.js
+++ b/app/frontend/editor/plugins/i18n.js
@@ -4,24 +4,9 @@ import messages from '@/locales'
 
 Vue.use(VueI18n)
 
-const AVAILABLE_LOCALES = ['en', 'fr']
-var locale = 'en'
-
-if (document.documentElement.lang) {
-  // fetch the local from the HTML tag
-  locale = document.documentElement.lang
-} else {
-  // try to fetch the browser locale
-  const language = navigator.languages[0]
-  if (language) {
-    locale = language.split('-')[0]
-    if (AVAILABLE_LOCALES.indexOf(locale) === -1) locale = null
-  }
-}
-
 const i18n = new VueI18n({
-  locale,
-  fallbackLocale: AVAILABLE_LOCALES[0],
+  locale: window.uiLocale,
+  fallbackLocale: 'en',
   messages,
 })
 

--- a/app/views/maglev/editor/show.html.erb
+++ b/app/views/maglev/editor/show.html.erb
@@ -8,6 +8,7 @@
 
   <%= javascript_tag nonce: true do %>
     window.locale = <%= h content_locale.to_json.html_safe %>;
+    window.uiLocale = <%= h editor_ui_locale.to_json.html_safe %>;
     window.baseUrl = <%= h site_base_editor_path.to_json.html_safe %>;
     window.leaveUrl = <%= site_leave_editor_path.to_json.html_safe %>;
     window.apiBaseUrl = <%= h api_base_path.to_json.html_safe %>;


### PR DESCRIPTION
- [x] the Maglev preview controller was erasing the `::I18n.locale` for the whole application which could lead to weird behaviors.
- [x] the editor UI locale relies exclusively and directly on the `editor_ui_locale` controller helper.