### PR TITLE
fix: make sure the default value of translatable attributes work in MySQL

### DIFF
--- a/app/models/concerns/maglev/translatable.rb
+++ b/app/models/concerns/maglev/translatable.rb
@@ -8,7 +8,8 @@ module Maglev
     extend ActiveSupport::Concern
 
     def translations_for(attr)
-      public_send("#{attr}_translations")
+      # With MySQL, the Jsonb field becomes nil when the field is not set, causing the default value to be discarded
+      public_send("#{attr}_translations").presence || {}
     end
 
     def translate_attr_in(attr, locale, source_locale)

--- a/spec/models/maglev/page_spec.rb
+++ b/spec/models/maglev/page_spec.rb
@@ -7,6 +7,21 @@ RSpec.describe Maglev::Page, type: :model do
     expect(build(:page)).to be_valid
   end
 
+  describe 'JSON translation fields initialization' do
+    it 'initializes translation fields with empty hashes when nil' do
+      # Create a page without setting translation fields (simulating MySQL behavior)
+      page = described_class.new(title_translations: nil)
+      expect(page.title).to eq nil
+    end
+
+    it 'preserves existing translation values when not nil' do
+      existing_translations = { en: 'Test Title' }
+      page = described_class.new(title_translations: existing_translations)
+
+      expect(page.title_translations).to eq(existing_translations.stringify_keys)
+    end
+  end
+
   describe '#index?' do
     subject { page.index? }
 


### PR DESCRIPTION
The default value of a JSONB attribute defined in a AR migration doesn't work well in MySQL causing bugs.