### PR TITLE
Fix section screenshot URLs to use Rails asset_host when available

### DIFF
--- a/app/services/maglev/fetch_section_screenshot_path.rb
+++ b/app/services/maglev/fetch_section_screenshot_path.rb
@@ -11,7 +11,34 @@ module Maglev
 
     def call
       path = "#{fetch_sections_path.call(theme: theme)}/#{section.category}/#{section.id}.jpg"
-      absolute ? Rails.root.join("public/#{path}").to_s : "/#{path}"
+      
+      if absolute
+        Rails.root.join("public/#{path}").to_s
+      else
+        # For section screenshot/preview images, check if we should use asset_host
+        # This fixes the Maglev editor preview images when static serving is disabled
+        asset_host = Rails.application.config.asset_host || 
+                    Rails.application.config.action_controller.asset_host
+        
+        if asset_host.present?
+          # If asset_host is a proc, evaluate it with lazy evaluation
+          if asset_host.respond_to?(:call)
+            request_stub = OpenStruct.new(ssl?: Rails.env.production?, host: 'example.com')
+            host = asset_host.call(path, request_stub)
+          else
+            host = asset_host
+          end
+          
+          if host.present?
+            # Ensure host doesn't end with slash and build full URL
+            "#{host.chomp('/')}/#{path}"
+          else
+            "/#{path}"
+          end
+        else
+          "/#{path}"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR fixes 500 errors for section preview images in the Maglev editor when static file serving is disabled in production environments.

## Problem

When Rails applications have static file serving disabled (common in production with CDN usage), section screenshot URLs in the Maglev editor fail with 500 errors because they try to serve static assets directly from the application server.

## Solution

- Update `FetchSectionScreenshotPath` service to check for Rails `asset_host` configuration
- Support both string and proc `asset_host` configurations with proper evaluation
- Generate full CDN URLs for section screenshots when `asset_host` is configured
- Only affects section screenshot/preview images in the editor, not content images

## Testing

- Tested with both string and proc asset_host configurations
- Verified lazy evaluation for proc-based asset_host
- Confirmed fix resolves 500 errors in staging environment

This change ensures section preview images work correctly in production environments using CDNs while maintaining backward compatibility.