### PR TITLE
feat: use the Rails asset host to generate the URL of the static section screenshots

### DIFF
--- a/app/services/maglev/fetch_section_screenshot_url.rb
+++ b/app/services/maglev/fetch_section_screenshot_url.rb
@@ -8,7 +8,18 @@ module Maglev
     argument :section
 
     def call
-      fetch_section_screenshot_path.call(section: section) + "?#{section.screenshot_timestamp}"
+      screenshot_path = fetch_section_screenshot_path.call(section: section) + query_string
+      asset_host ? URI.join(asset_host, screenshot_path).to_s : screenshot_path
+    end
+
+    private
+
+    def asset_host
+      Rails.application.config.asset_host
+    end
+
+    def query_string
+      "?#{section.screenshot_timestamp}"
     end
   end
 end

--- a/lib/maglev.rb
+++ b/lib/maglev.rb
@@ -29,7 +29,7 @@ module Maglev
         c.uploader = :active_storage
         c.site_publishable = false
         c.preview_host = nil
-        c.asset_host = Rails.application.config.action_controller.asset_host
+        c.asset_host = Rails.application.config.asset_host
         c.ui_locale = nil
         c.back_action = nil
         c.services = {}

--- a/spec/services/maglev/fetch_section_screenshot_url_spec.rb
+++ b/spec/services/maglev/fetch_section_screenshot_url_spec.rb
@@ -13,4 +13,14 @@ describe Maglev::FetchSectionScreenshotUrl do
   it 'returns the url to the screenshot of the section' do
     expect(subject).to eq '/theme/jumbotron.png?42'
   end
+
+  context 'when there is a Rails asset host set' do
+    before do
+      allow(Rails.application.config).to receive(:asset_host).and_return('https://assets.maglev.local')
+    end
+
+    it 'uses the Rails asset host to build the url' do
+      expect(subject).to eq 'https://assets.maglev.local/theme/jumbotron.png?42'
+    end
+  end
 end


### PR DESCRIPTION
We basically need it when the Rails application doesn't serve static assets.

Further explanation -> https://github.com/maglevhq/maglev-core/pull/184

