### PR TITLE
feat: missing block labels translations

### DIFF
--- a/app/frontend/editor/components/section-pane/block-list/new-block-button.vue
+++ b/app/frontend/editor/components/section-pane/block-list/new-block-button.vue
@@ -17,10 +17,10 @@
           <button
             v-for="blockType in blockTypes"
             :key="blockType.type"
-            class="mb-2 text-base text-gray-900 py-2 px-14 hover:bg-gray-100 transition-colors"
+            class="mb-2 text-base text-gray-900 py-2 px-14 hover:bg-gray-100 transition-colors text-left"
             @click="addSectionBlockAndClose(blockType.type)"
           >
-            {{ blockType.name }}
+            {{ blockTypeLabel(blockType) }}
           </button>
         </div>
       </template>
@@ -56,6 +56,9 @@ export default {
         )
       else return this.currentSectionDefinition.blocks
     },
+    currentBlockTypesI18nScope() {
+      return `${this.currentSectionI18nScope}.blocks.types`
+    }
   },
   methods: {
     ...mapActions(['addSectionBlock']),
@@ -63,6 +66,9 @@ export default {
       this.addSectionBlock({ blockType })
       this.$refs.dropdown.close()
     },
+    blockTypeLabel(blockType) {
+      return this.$st(`${this.currentBlockTypesI18nScope}.${blockType.type}`) ?? blockType.name
+    }
   },
 }
 </script>

--- a/app/frontend/editor/components/section-pane/block-tree/new-nested-block-button.vue
+++ b/app/frontend/editor/components/section-pane/block-tree/new-nested-block-button.vue
@@ -15,10 +15,10 @@
           <button
             v-for="blockType in blockTypes"
             :key="blockType.type"
-            class="mb-2 text-base text-gray-900 py-2 px-4 hover:bg-gray-100 transition-colors"
+            class="mb-2 text-base text-gray-900 py-2 px-4 hover:bg-gray-100 transition-colors text-left"
             @click="addNestedSectionBlockAndClose(blockType.type)"
           >
-            {{ blockType.name }}
+            {{ blockTypeLabel(blockType) }}
           </button>
         </div>
       </template>
@@ -49,6 +49,9 @@ export default {
         (block) => this.accept.indexOf(block.type) !== -1,
       )
     },
+    currentBlockTypesI18nScope() {
+      return `${this.currentSectionI18nScope}.blocks.types`
+    }
   },
   methods: {
     ...mapActions(['addSectionBlock']),
@@ -61,6 +64,9 @@ export default {
     addNestedSectionBlockAndClose(blockType) {
       this.addSectionBlock({ blockType, parentId: this.parentId })
       this.$refs.dropdown.close()
+    },
+    blockTypeLabel(blockType) {
+      return this.$st(`${this.currentBlockTypesI18nScope}.${blockType.type}`) ?? blockType.name
     },
   },
 }

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -34,3 +34,14 @@ en:
   lang:
     en: "English"
     fr: "Français"
+
+  # maglev:
+  #   themes:
+  #     simple:
+  #       sections:
+  #         navbar:
+  #           blocks:
+  #             label: "Menu 🍔"
+  #             types:
+  #               menu_item: "Menu item 🤬"
+  #               alt_menu_item: "Alt Menu item 🍪"


### PR DESCRIPTION
allow to translate the label of the blocks tab pane and also the block types in the dropdown when adding a new block.