### PR TITLE
Inherit from ActionController::Base

### DIFF
--- a/app/controllers/maglev/application_controller.rb
+++ b/app/controllers/maglev/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Maglev
-  class ApplicationController < ::ApplicationController
+  class ApplicationController < ActionController::Base
     include Maglev::ServicesConcern
     include Maglev::ResourceIdConcern
     include Maglev::ErrorsConcern


### PR DESCRIPTION
Some applications might not have `ApplicationController` inside their application, or they rename it to something else, leading to 
```
/Users/chedli/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/maglevcms-2.1.0/app/controllers/maglev/application_controller.rb:4:in '<module:Maglev>': uninitialized constant ApplicationController (NameError)
```

and using autoloaded constants is not very `zeitwerk` friendly as well